### PR TITLE
Add CSRF_TRUSTED_ORIGINS variable.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
             DJANGO_SETTINGS_MODULE: webapp.settings
             SECRET_KEY: c0b395ac13212cb5251c5f55eab9ed8a518ce7793c9971076153860bab4e0290
             ALLOWED_HOSTS: localhost,localhost:8000
+            CSRF_TRUSTED_ORIGINS: http://localhost
             
         working_directory: ~/app
 

--- a/README.rst
+++ b/README.rst
@@ -407,6 +407,12 @@ and a link to "Add".
 Environment Variables
 ---------------------
 
+CSRF_TRUSTED_ORIGINS
+~~~~~~~~~~~~~~~~~~~~
+Required for Django 4 and above. Separate multiple trusted origins with commas.
+
+Further documentation can be found here: https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins
+
 WEBAPP_SECRET_KEY
 ~~~~~~~~~~~~~~~~~
 

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -284,3 +284,6 @@ AUTHBROKER_URL = os.environ.get("AUTHBROKER_URL")
 AUTHBROKER_CLIENT_ID = os.environ.get("AUTHBROKER_CLIENT_ID")
 AUTHBROKER_CLIENT_SECRET = os.environ.get("AUTHBROKER_CLIENT_SECRET")
 AUTHBROKER_SCOPES = "read write"
+
+# CSRF variable required for Django 4
+CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS").split(",")


### PR DESCRIPTION
Adds support for a `CSRF_TRUSTED_ORIGINS` environment variable, required for Django 4.0 and above.